### PR TITLE
Bump node-canvas version so that it runs (better) on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies" : {
         "color-convert" : "0.2.x",
-        "canvas" : "1.0.x"
+        "canvas" : "1.4.x"
     },
     "devDependencies" : {
         "expresso" : "0.7.x",


### PR DESCRIPTION
Wasn't able to `npm install` `node-heatmap`, because of a `node-gyp` compiler error. This is a known issue in Canvas and has been fixed in a later version than 1.0.x (see: https://github.com/Automattic/node-canvas/issues/605)

Bumping the version solved the issues for me, my use of `node-heatmap` still worked; didn't test much else though.